### PR TITLE
Python3 fixes

### DIFF
--- a/autoload/ocpindent.py
+++ b/autoload/ocpindent.py
@@ -54,9 +54,9 @@ def ocp_indent(lines):
   process = subprocess.Popen(
       [ocp_indent_path] + args + ["--lines",lines,"--numeric"],
       stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=open(os.devnull,"w"))
-  process.stdin.write(content)
+  process.stdin.write(content.encode())
   process.stdin.close()
-  return map(int,process.stdout.readlines())
+  return [int(line) for line in process.stdout.readlines()]
 
 def vim_contiguous(line1, line2):
   if not line1 or not line2: return False


### PR DESCRIPTION
On a vim build that supports only python3 (such as the version in Debian testing at the moment, `2:8.0.0003-1+b1`), `ocp-indent-vim` fails: it always indents to 0 spaces.

This is because of a compatibility problem of the `ocpindent` python module with python 3:

- pipes work on bytes, not strings, so it is necessary to `encode()` the `content` variable.
- `map` returns an iterator instead of a list, so it has no `pop()` method.